### PR TITLE
Fix StripeJs creating a duplicate PaymentIntent on payment page reload

### DIFF
--- a/spec/Action/StripeJs/CaptureActionSpec.php
+++ b/spec/Action/StripeJs/CaptureActionSpec.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\FluxSE\SyliusPayumStripePlugin\Action\StripeJs;
+
+use FluxSE\PayumStripe\Action\StripeJs\CaptureAction as BaseCaptureAction;
+use FluxSE\PayumStripe\Request\CaptureAuthorized;
+use FluxSE\PayumStripe\Request\StripeJs\Api\RenderStripeJs;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\GatewayInterface;
+use Payum\Core\Request\Capture;
+use Payum\Core\Request\Sync;
+use Payum\Core\Security\TokenInterface;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Collaborator;
+use Prophecy\Argument;
+
+final class CaptureActionSpec extends ObjectBehavior
+{
+    /**
+     * @param Collaborator|GatewayInterface $gateway
+     */
+    public function let(GatewayInterface $gateway): void
+    {
+        $this->setGateway($gateway);
+    }
+
+    public function it_is_a_stripe_js_capture_action(): void
+    {
+        $this->shouldHaveType(BaseCaptureAction::class);
+    }
+
+    /**
+     * @param Capture|Collaborator $request
+     * @param Collaborator|TokenInterface $token
+     * @param Collaborator|GatewayInterface $gateway
+     */
+    public function it_renders_the_form_again_when_the_reused_payment_intent_is_still_payable(
+        Capture $request,
+        TokenInterface $token,
+        GatewayInterface $gateway
+    ): void {
+        $model = new ArrayObject([
+            'id' => 'pi_123',
+            'object' => 'payment_intent',
+            'status' => 'requires_payment_method',
+        ]);
+
+        $request->getModel()->willReturn($model);
+        $request->getToken()->willReturn($token);
+        $token->getAfterUrl()->willReturn('https://example.com/after');
+
+        $gateway->execute(Argument::type(Sync::class))->shouldBeCalled();
+        $gateway->execute(Argument::type(CaptureAuthorized::class))->shouldBeCalled();
+        $gateway->execute(Argument::type(RenderStripeJs::class))->shouldBeCalled();
+
+        $this->execute($request);
+    }
+
+    /**
+     * @param Capture|Collaborator $request
+     * @param Collaborator|TokenInterface $token
+     * @param Collaborator|GatewayInterface $gateway
+     */
+    public function it_does_not_render_the_form_when_the_reused_payment_intent_is_no_longer_payable(
+        Capture $request,
+        TokenInterface $token,
+        GatewayInterface $gateway
+    ): void {
+        $model = new ArrayObject([
+            'id' => 'pi_123',
+            'object' => 'payment_intent',
+            'status' => 'succeeded',
+        ]);
+
+        $request->getModel()->willReturn($model);
+        $request->getToken()->willReturn($token);
+
+        $gateway->execute(Argument::type(Sync::class))->shouldBeCalled();
+        $gateway->execute(Argument::type(CaptureAuthorized::class))->shouldBeCalled();
+        $gateway->execute(Argument::type(RenderStripeJs::class))->shouldNotBeCalled();
+
+        $this->execute($request);
+    }
+
+    /**
+     * @param Capture|Collaborator $request
+     */
+    public function it_supports_a_capture_request_with_an_array_access_model(
+        Capture $request
+    ): void {
+        $request->getModel()->willReturn(new ArrayObject([]));
+
+        $this->supports($request)->shouldReturn(true);
+    }
+}

--- a/spec/Action/StripeJs/ConvertPaymentActionSpec.php
+++ b/spec/Action/StripeJs/ConvertPaymentActionSpec.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\FluxSE\SyliusPayumStripePlugin\Action\StripeJs;
+
+use FluxSE\SyliusPayumStripePlugin\Action\StripeJs\ConvertPaymentAction;
+use FluxSE\SyliusPayumStripePlugin\Action\StripeJs\ConvertPaymentActionInterface;
+use FluxSE\SyliusPayumStripePlugin\Provider\StripeJs\DetailsProviderInterface;
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Request\Convert;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Collaborator;
+use Sylius\Component\Core\Model\PaymentInterface;
+
+final class ConvertPaymentActionSpec extends ObjectBehavior
+{
+    /**
+     * @param Collaborator|DetailsProviderInterface $detailsProvider
+     */
+    public function let(DetailsProviderInterface $detailsProvider): void
+    {
+        $this->beConstructedWith($detailsProvider);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ConvertPaymentAction::class);
+    }
+
+    public function it_implements_action_interface(): void
+    {
+        $this->shouldHaveType(ActionInterface::class);
+        $this->shouldHaveType(ConvertPaymentActionInterface::class);
+    }
+
+    /**
+     * @param Convert|Collaborator $request
+     * @param Collaborator|PaymentInterface $payment
+     * @param Collaborator|DetailsProviderInterface $detailsProvider
+     */
+    public function it_returns_existing_details_when_an_id_is_already_set(
+        Convert $request,
+        PaymentInterface $payment,
+        DetailsProviderInterface $detailsProvider
+    ): void {
+        $details = ['id' => 'pi_123', 'object' => 'payment_intent'];
+        $payment->getDetails()->willReturn($details);
+        $request->getSource()->willReturn($payment);
+        $request->getTo()->willReturn('array');
+
+        $detailsProvider->getDetails($payment)->shouldNotBeCalled();
+        $request->setResult($details)->shouldBeCalled();
+
+        $this->execute($request);
+    }
+
+    /**
+     * @param Convert|Collaborator $request
+     * @param Collaborator|PaymentInterface $payment
+     * @param Collaborator|DetailsProviderInterface $detailsProvider
+     */
+    public function it_builds_fresh_details_when_no_id_is_set(
+        Convert $request,
+        PaymentInterface $payment,
+        DetailsProviderInterface $detailsProvider
+    ): void {
+        $freshDetails = ['amount' => 1000, 'currency' => 'usd'];
+        $payment->getDetails()->willReturn([]);
+        $request->getSource()->willReturn($payment);
+        $request->getTo()->willReturn('array');
+        $detailsProvider->getDetails($payment)->willReturn($freshDetails);
+
+        $request->setResult($freshDetails)->shouldBeCalled();
+
+        $this->execute($request);
+    }
+
+    /**
+     * @param Convert|Collaborator $request
+     * @param Collaborator|PaymentInterface $payment
+     */
+    public function it_supports_only_convert_request_payment_source_and_array_to(
+        Convert $request,
+        PaymentInterface $payment
+    ): void {
+        $request->getSource()->willReturn($payment);
+        $request->getTo()->willReturn('array');
+
+        $this->supports($request)->shouldReturn(true);
+    }
+}

--- a/src/Action/StripeJs/CaptureAction.php
+++ b/src/Action/StripeJs/CaptureAction.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumStripePlugin\Action\StripeJs;
+
+use ArrayObject;
+use FluxSE\PayumStripe\Action\StripeJs\CaptureAction as BaseCaptureAction;
+use Payum\Core\Request\Generic;
+use Stripe\PaymentIntent;
+
+final class CaptureAction extends BaseCaptureAction
+{
+    /**
+     * When an existing PaymentIntent is reused (the model already has an `id`), the base action only syncs it
+     * and lets Payum redirect to the capture token after URL. If the buyer reloads the payment page before paying,
+     * the PaymentIntent is still awaiting payment, so that redirect leaves them stuck on the order summary with
+     * no way to complete the payment.
+     *
+     * Re-render the Stripe Elements form whenever the reused PaymentIntent is still in a payable state, so the buyer
+     * can pay the very same intent (no duplicate intent is created).
+     */
+    protected function processNotNew(ArrayObject $model, Generic $request): void
+    {
+        parent::processNotNew($model, $request);
+
+        /** @var string|null $status */
+        $status = $model->offsetGet('status');
+        if (!in_array($status, [
+            PaymentIntent::STATUS_REQUIRES_PAYMENT_METHOD,
+            PaymentIntent::STATUS_REQUIRES_CONFIRMATION,
+            PaymentIntent::STATUS_REQUIRES_ACTION,
+        ], true)) {
+            return;
+        }
+
+        $paymentIntent = PaymentIntent::constructFrom($model->getArrayCopy());
+        $this->render($paymentIntent, $request);
+    }
+}

--- a/src/Action/StripeJs/ConvertPaymentAction.php
+++ b/src/Action/StripeJs/ConvertPaymentAction.php
@@ -27,6 +27,15 @@ final class ConvertPaymentAction implements ConvertPaymentActionInterface
         /** @var PaymentInterface $payment */
         $payment = $request->getSource();
 
+        $details = $payment->getDetails();
+
+        $id = $details['id'] ?? null;
+        if (is_string($id) && $id !== '') {
+            $request->setResult($details);
+
+            return;
+        }
+
         $details = $this->detailsProvider->getDetails($payment);
 
         $request->setResult($details);

--- a/src/Resources/config/services/stripe_js/payum.yaml
+++ b/src/Resources/config/services/stripe_js/payum.yaml
@@ -1,11 +1,19 @@
 services:
+    flux_se.sylius_payum_stripe.action.stripe_js.convert_payment:
+        public: true
+        class: FluxSE\SyliusPayumStripePlugin\Action\StripeJs\ConvertPaymentAction
+        arguments:
+            $detailsProvider: '@flux_se.sylius_payum_stripe.provider.stripe_js.details'
+        tags:
+            -   name: payum.action
+                factory: stripe_js
+                alias: flux_se.sylius_payum_stripe.convert_payment
 
-  flux_se.sylius_payum_stripe.action.stripe_js.convert_payment:
-    public: true
-    class: FluxSE\SyliusPayumStripePlugin\Action\StripeJs\ConvertPaymentAction
-    arguments:
-      $detailsProvider: '@flux_se.sylius_payum_stripe.provider.stripe_js.details'
-    tags:
-      - name: payum.action
-        factory: stripe_js
-        alias: flux_se.sylius_payum_stripe.convert_payment
+    flux_se.sylius_payum_stripe.action.stripe_js.capture:
+        public: true
+        class: FluxSE\SyliusPayumStripePlugin\Action\StripeJs\CaptureAction
+        tags:
+            -   name: payum.action
+                factory: stripe_js
+                alias: flux_se.sylius_payum_stripe.capture
+                prepend: true


### PR DESCRIPTION
Fixes #76

### Problem

With the **Stripe JS** gateway, reloading the payment page before paying left the buyer unable to complete the payment:

- A new `PaymentIntent` was created on each reload, and its id overwrote the reference to the original intent in `payment.details['id']`. If the buyer then paid the original intent, the webhook/sync reconciled against the stale stored one and the order stayed unpaid.
- Once the stored intent was reused, the capture action only synced it and let Payum redirect to the order summary, so the buyer was bounced to the summary on every retry and the `PaymentIntent` stayed `incomplete` forever.

### Fix

1. **Preserve the existing PaymentIntent id** in the Stripe JS `ConvertPaymentAction` (mirrors the Checkout Session behavior), so a reload reuses the same intent instead of creating a duplicate.
2. **Re-render the Stripe Elements form** when a reused PaymentIntent is still in a payable state (`requires_payment_method` / `requires_confirmation` / `requires_action`), via a custom Stripe JS `CaptureAction`, instead of redirecting to the after URL. Other statuses keep the existing behavior, and the headless API flow is unaffected (the render reply is caught and the `client_secret` is still returned).